### PR TITLE
Add Templating Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Secret management for NixOS.
 Highly inspired by agenix-rekey and sops-nix. Based on rust age crate.
 
 + Age Plugin Compatible
++ Support Template
 + Support identity with passphase
 + Support PIV Card (Yubikey)
-+ Support Template
 + No Bash
 
 ## Setup
@@ -81,14 +81,24 @@ Adding nixosModule config:
         # path = "/some/place";
       };
     };
+
+    # the templating function acts the same as sops-nix
+    templates = {
+      test = {
+        name = "template.txt";
+        # to be notice that the source secret file may have trailing `\n`
+        content = "this is a template for testing ${config.vaultix.placeholder.example}";
+      };
+    }
   };
 }
 ```
 
-After this you could reference the decrypted secret path by:
+After this you could reference the path by:
 
 ```
-<AnyPathOption> = config.vaultix.secrets.example.path;
+<A-PathOption> = config.vaultix.secrets.example.path;
+<B-PathOption> = config.vaultix.templates.test.path;
 # ...
 ```
 
@@ -139,3 +149,4 @@ See [TODO](./TODO.md)
 
 + [agenix](https://github.com/ryantm/agenix)
 + [agenix-rekey](https://github.com/oddlama/agenix-rekey)
++ [sops-nix](https://github.com/Mic92/sops-nix)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 
 Secret management for NixOS.
 
-Highly inspired by agenix-rekey. Based on rust age crate.
+Highly inspired by agenix-rekey and sops-nix. Based on rust age crate.
 
-+ AGE Support Only
-+ PIV Card (Yubikey) Support
 + Age Plugin Compatible
++ Support identity with passphase
++ Support PIV Card (Yubikey)
++ Support Template
 + No Bash
 
 ## Setup

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-- [ ] template
+- [x] template
 - [ ] [edit] or [add] secret with extra encrypt key
 - [ ] deploy to specified location
 - [x] check command

--- a/module/default.nix
+++ b/module/default.nix
@@ -227,14 +227,15 @@ let
           Group of the decrypted secret.
         '';
       };
-      symlink = mkEnableOption "symlinking secrets to their destination" // {
+      symlink = mkEnableOption "symlinking secrets to destination" // {
         default = true;
       };
     };
   });
-
 in
 {
+  imports = [ ./template.nix ];
+
   options.vaultix = {
 
     package = mkOption { defaultText = literalMD "`packages.vaultix` from this flake"; };
@@ -254,7 +255,11 @@ in
         Attrset of secrets.
       '';
     };
+  };
 
+  options.vaultix-debug = mkOption {
+    type = types.unspecified;
+    default = cfg;
   };
 
   config =

--- a/module/template.nix
+++ b/module/template.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  ...
+}:
+# this part basically inherit from
+# https://github.com/Mic92/sops-nix/tree/60e1bce1999f126e3b16ef45f89f72f0c3f8d16f/modules/sops/templates
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkDefault
+    mapAttrs
+    types
+    literalExpression
+    mkIf
+    ;
+  inherit (config.users) users;
+
+  cfg = config.vaultix;
+
+  templateType = types.submodule (submod: {
+    options = {
+      content = mkOption {
+        type = types.str;
+        default = "";
+        defaultText = literalExpression "";
+        description = ''
+          Content of the template
+        '';
+      };
+      name = mkOption {
+        type = types.str;
+        default = submod.config._module.args.name;
+        defaultText = literalExpression "submod.config._module.args.name";
+        description = ''
+          Name of the file used in {option}`vaultix.settings.decryptedDir`
+        '';
+      };
+      path = mkOption {
+        type = types.str;
+        default = "${cfg.settings.decryptedDir}/${submod.config.name}";
+        defaultText = literalExpression ''
+          "''${cfg.settings.decryptedDir}/''${config.name}"
+        '';
+        description = ''
+          Path where the built template is installed.
+        '';
+      };
+      mode = mkOption {
+        type = types.str;
+        default = "0400";
+        description = ''
+          Permissions mode of the built template in a format understood by chmod.
+        '';
+      };
+      owner = mkOption {
+        type = types.str;
+        default = "0";
+        description = ''
+          User of the built template.
+        '';
+      };
+      group = mkOption {
+        type = types.str;
+        default = users.${submod.config.owner}.group or "0";
+        defaultText = literalExpression ''
+          users.''${config.owner}.group or "0"
+        '';
+        description = ''
+          Group of the built template.
+        '';
+      };
+      symlink = mkEnableOption "symlinking template to destination" // {
+        default = true;
+      };
+    };
+  });
+
+in
+{
+  options.vaultix = {
+
+    templates = mkOption {
+      type = types.attrsOf templateType;
+      default = { };
+      description = ''
+        Attrset of templates.
+      '';
+    };
+
+    placeholder = mkOption {
+      type = types.attrsOf (
+        types.mkOptionType {
+          name = "coercibleToString";
+          description = "value that can be coerced to string";
+          check = lib.strings.isConvertibleWithToString;
+          merge = lib.mergeEqualOption;
+        }
+      );
+      default = { };
+      visible = false;
+      description = ''
+        Identical with the attribute name of secrets, NOTICE this if you
+        defined the `name` in secrets submodule.
+      '';
+    };
+  };
+  config = mkIf (config.vaultix.templates != { }) {
+    vaultix.placeholder = mapAttrs (
+      n: _: mkDefault "{{ ${builtins.hashString "sha256" n} }}"
+    ) cfg.secrets;
+  };
+}

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -240,11 +240,7 @@ impl Profile {
                 .collect();
 
             self.templates.clone().iter().for_each(|(_, t)| {
-                // TODO:
-                // parse content -> [hash]
-
-                let mut raw_template = t.content.clone();
-
+                let mut template = t.content.clone();
                 let hashstrs_of_it = t.parse_hash_str_list().expect("parse template");
 
                 hashstr_ctx_map
@@ -252,16 +248,16 @@ impl Profile {
                     .filter(|(k, _)| hashstrs_of_it.contains(*k))
                     .for_each(|(k, v)| {
                         // render
-                        trace!("template before process: {}", raw_template);
-                        raw_template = raw_template.replace(
+                        trace!("template before process: {}", template);
+                        template = template.replace(
                             format!("{{{{ {} }}}}", k).as_str(),
                             String::from_utf8_lossy(v).to_string().as_str(),
                         );
-                        trace!("processed template: {}", raw_template);
+                        trace!("processed template: {}", template);
                     });
 
                 deploy_to_fs(
-                    SecBuf::<Plain>::new(raw_template.into_bytes()),
+                    SecBuf::<Plain>::new(template.into_bytes()),
                     t,
                     generation_count,
                     target_extract_dir_with_gen.clone(),

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -4,3 +4,4 @@ pub mod parse_permission;
 pub mod secret_buf;
 pub mod set_owner_group;
 pub mod stored;
+pub mod template;

--- a/src/helper/secret_buf.rs
+++ b/src/helper/secret_buf.rs
@@ -11,6 +11,7 @@ pub struct HostEnc;
 #[derive(Debug, Clone)]
 pub struct Plain;
 
+#[derive(Debug, Clone)]
 pub struct SecBuf<T> {
     buf: Vec<u8>,
     _marker: PhantomData<T>,
@@ -22,6 +23,9 @@ impl<T> SecBuf<T> {
             buf: i,
             _marker: PhantomData,
         }
+    }
+    pub fn inner(self) -> Vec<u8> {
+        self.buf
     }
 }
 
@@ -41,6 +45,15 @@ impl<T> SecBuf<T> {
             debug!("decrypted secret {} bytes", b);
         }
         Ok(SecBuf::new(dec_ctx))
+    }
+}
+
+impl<T> From<Vec<u8>> for SecBuf<T> {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            buf: value,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/src/helper/template.rs
+++ b/src/helper/template.rs
@@ -1,0 +1,186 @@
+use crate::profile::Template;
+use eyre::Result;
+use nom::{
+    bytes::complete::{is_not, tag, take_while_m_n},
+    error::Error,
+    sequence::delimited,
+    IResult,
+};
+
+fn parse_braced_hash(input: &str) -> IResult<&str, &str, Error<&str>> {
+    delimited(
+        tag("{{ "),
+        take_while_m_n(64, 64, |c: char| c.is_ascii_hexdigit()),
+        tag(" }}"),
+    )(input)
+}
+
+fn pars<'a>(text: &'a str, res: &mut Vec<&'a str>) {
+    let (remaining, _) = is_not::<&str, &str, Error<&str>>("{{")(text).expect("here");
+    match parse_braced_hash(remaining) {
+        Ok((remain, hashes)) => {
+            res.push(hashes);
+            if !remain.is_empty() {
+                pars(remain, res);
+            }
+        }
+        Err(_e) => {
+            // warn!("parse template terminate: {:?}", e);
+        }
+    };
+}
+
+impl Template {
+    pub fn parse_hash_str_list(&self) -> Result<Vec<String>> {
+        let text = &self.content;
+
+        let mut res = vec![];
+        let text = format!(" {}", text); // hack
+        pars(text.as_str(), &mut res);
+        Ok(res.into_iter().map(|s| String::from(s)).collect())
+    }
+}
+
+// pub struct Template
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Default for Template {
+        fn default() -> Self {
+            let string_default = String::default();
+            Template {
+                name: string_default.clone(),
+                content: string_default.clone(),
+                group: string_default.clone(),
+                mode: string_default.clone(),
+                owner: string_default.clone(),
+                path: string_default,
+                symlink: true,
+            }
+        }
+    }
+
+    #[test]
+    fn parse_template_single() {
+        let str =
+            "here has {{ dcd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440aa93 }} whch should be replaced";
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert_eq!(
+            vec!["dcd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440aa93"],
+            t.parse_hash_str_list().unwrap()
+        )
+    }
+    #[test]
+    fn parse_template_multi() {
+        let str = "here {{ dcd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440aa93 }} {{ cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93 }}";
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert_eq!(
+            vec![
+                "dcd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440aa93",
+                "cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93"
+            ],
+            t.parse_hash_str_list().unwrap()
+        )
+    }
+    #[test]
+    fn parse_template_with_trailing_white() {
+        let str = "{{ cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93 }} ";
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert_eq!(
+            vec!["cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93",],
+            t.parse_hash_str_list().unwrap()
+        )
+    }
+    #[test]
+    fn parse_template_with_heading_white() {
+        let str = " {{ cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93 }}";
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert_eq!(
+            vec!["cd789434d890685da841b8db8a02b0173b90eac3774109ba9bca1b81440a2a93",],
+            t.parse_hash_str_list().unwrap()
+        )
+    }
+    #[test]
+    fn parse_template_none() {
+        let str = "";
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert!(t.parse_hash_str_list().unwrap().len() == 0)
+    }
+    #[test]
+    fn parse_template_multi_line_truncate() {
+        let str = r#"some {{ d9cd8155764c3543f10fad8a480d743137466f8d55213c8eaefcd12f06d43a80
+        }}"#;
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert!(t.parse_hash_str_list().unwrap().len() == 0)
+    }
+    #[test]
+    fn parse_template_invalid_length_of_hash() {
+        let str = r#"some {{ 8155764c3543f10fad8a480d743137466f8d55213c8eaefcd12f06d43a80 }}"#;
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert!(t.parse_hash_str_list().unwrap().len() == 0)
+    }
+    #[test]
+    fn parse_template_open() {
+        let str = r#"some {{ 8155764c3543f10fad8a480d743137466f8d55213c8eaefcd12f06d43a80"#;
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert!(t.parse_hash_str_list().unwrap().len() == 0)
+    }
+    #[test]
+    fn parse_template_whatever() {
+        let str = r#"some {{ 8155{{764c3543f10fad8a480d743137466f8d55213c8eaefcd12f06d43a\8}}0"#;
+
+        let t = Template {
+            content: String::from(str),
+            ..Template::default()
+        };
+        assert!(t.parse_hash_str_list().unwrap().len() == 0)
+    }
+    #[test]
+    fn render() {
+        let s: String = String::from("{{ hash }}");
+
+        assert_eq!(
+            "some",
+            s.replace(concat!("{{ ", "hash", " }}").trim(), "some")
+        );
+        assert_eq!(
+            "some",
+            // holy
+            s.replace(format!("{{{{ {} }}}}", "hash").trim(), "some")
+        );
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 pub type SecretSet = HashMap<String, Secret>;
+pub type TemplateSet = HashMap<String, Template>;
 
 #[derive(Debug, Deserialize)]
 pub struct Profile {
     pub secrets: SecretSet,
     pub settings: Settings,
+    pub templates: TemplateSet,
 }
 
 #[derive(Debug, Deserialize, Clone, Hash, Eq, PartialEq)]
@@ -17,6 +19,17 @@ pub struct Secret {
     pub group: String,
     pub mode: String,
     pub name: String,
+    pub owner: String,
+    pub path: String,
+    pub symlink: bool,
+}
+
+#[derive(Debug, Deserialize, Clone, Hash, Eq, PartialEq)]
+pub struct Template {
+    pub name: String,
+    pub content: String,
+    pub group: String,
+    pub mode: String,
     pub owner: String,
     pub path: String,
     pub symlink: bool,
@@ -48,3 +61,35 @@ pub struct HostKey {
     pub path: String,
     pub r#type: String,
 }
+
+pub trait DeployFactor {
+    fn get_mode(&self) -> &String;
+    fn get_owner(&self) -> &String;
+    fn get_name(&self) -> &String;
+    fn get_group(&self) -> &String;
+}
+
+macro_rules! impl_deploy_factor {
+    ($type:ty, { $($method:ident => $field:ident),+ $(,)? }) => {
+        impl DeployFactor for $type {
+            $(
+                fn $method(&self) -> &String {
+                    &self.$field
+                }
+            )+
+        }
+    };
+}
+
+impl_deploy_factor!(&Secret, {
+    get_mode => mode,
+    get_owner => owner,
+    get_name => name,
+    get_group => group
+});
+impl_deploy_factor!(&Template, {
+    get_mode => mode,
+    get_owner => owner,
+    get_name => name,
+    get_group => group
+});


### PR DESCRIPTION
## Summary

The templating function acts the same as sops-nix.

```
templates = {
  test = {
    name = "template.txt";
    content = "this is a template for testing ${config.vaultix.placeholder.example}";
  };
}
```

2b noticed that the program remains the trailing `\n` of the secret file(if it exist), which may cause the output not as expected.

Support for inserting multiple secrets into a single template.